### PR TITLE
update paths to the four diploma files

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Tutustu Koodikouluun sivustolla [koodikoulu.fi](http://koodikoulu.fi)!
 Täältä Githubista löytyy materiaalia koodikoululaisille ja koodikoulun opettajille opetuksen tueksi. Materiaali on viimeistelemätöntä, ja siksipä kannustan sinua osallistumaan sen kehitykseen.
 
 - [Ensimmäinen tunti: Turtle Roy](https://github.com/koodikoulu/koodikoulu/blob/master/1_turtle_roy.md) (myös [opettajille](https://github.com/koodikoulu/koodikoulu/blob/master/1_turtle_roy_ope.md))
-- Koodikoulun todistus tulostettavaksi (neljä eri tyyliä: [ensimmäinen](https://github.com/koodikoulu/koodikoulu/raw/master/diplomi_koodikoulu.pdf), [toinen](https://github.com/koodikoulu/koodikoulu/raw/master/diplomi_koodikoulu2.pdf), [kolmas](https://github.com/koodikoulu/koodikoulu/raw/master/diplomi_koodikoulu3.pdf), [neljäs ](https://github.com/koodikoulu/koodikoulu/raw/master/diplomi_koodikoulu4.pdf))
+- Koodikoulun todistus tulostettavaksi, neljä eri tyyliä: [Ensimmäinen](https://github.com/koodikoulu/koodikoulu/raw/master/diplomi_koodikoulu.pdf), [toinen](https://github.com/koodikoulu/koodikoulu/raw/master/diplomi_koodikoulu2.pdf), [kolmas](https://github.com/koodikoulu/koodikoulu/raw/master/diplomi_koodikoulu3.pdf), [neljäs](https://github.com/koodikoulu/koodikoulu/raw/master/diplomi_koodikoulu4.pdf)
 - [Lasten Koodikoulu -tarra](https://github.com/koodikoulu/koodikoulu/raw/master/tarra2.pdf)
 - [Olen Kooditaituri -tarra](https://github.com/koodikoulu/koodikoulu/raw/master/tarra1.pdf)
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Tutustu Koodikouluun sivustolla [koodikoulu.fi](http://koodikoulu.fi)!
 Täältä Githubista löytyy materiaalia koodikoululaisille ja koodikoulun opettajille opetuksen tueksi. Materiaali on viimeistelemätöntä, ja siksipä kannustan sinua osallistumaan sen kehitykseen.
 
 - [Ensimmäinen tunti: Turtle Roy](https://github.com/koodikoulu/koodikoulu/blob/master/1_turtle_roy.md) (myös [opettajille](https://github.com/koodikoulu/koodikoulu/blob/master/1_turtle_roy_ope.md))
-- [Koodikoulun todistus](https://github.com/koodikoulu/koodikoulu/raw/master/diplomi.pdf) tulostettavaksi
+- Koodikoulun todistus tulostettavaksi (neljä eri tyyliä: [ensimmäinen](https://github.com/koodikoulu/koodikoulu/raw/master/diplomi_koodikoulu.pdf), [toinen](https://github.com/koodikoulu/koodikoulu/raw/master/diplomi_koodikoulu2.pdf), [kolmas](https://github.com/koodikoulu/koodikoulu/raw/master/diplomi_koodikoulu3.pdf), [neljäs ](https://github.com/koodikoulu/koodikoulu/raw/master/diplomi_koodikoulu4.pdf))
 - [Lasten Koodikoulu -tarra](https://github.com/koodikoulu/koodikoulu/raw/master/tarra2.pdf)
 - [Olen Kooditaituri -tarra](https://github.com/koodikoulu/koodikoulu/raw/master/tarra1.pdf)
 


### PR DESCRIPTION
There are four diploma files, thus the README.md link was broken. Updated it with links to all four.